### PR TITLE
support build on macOS.

### DIFF
--- a/androidbuildlib
+++ b/androidbuildlib
@@ -34,7 +34,12 @@ then
 fi
 
 out_path=libs
-host_tag=linux-x86_64
+# check system is linux or darwin
+if [ "$(uname)" == "Darwin" ]; then
+    host_tag=darwin-x86_64
+else
+    host_tag=linux-x86_64
+fi
 minsdkversion=18
 target_abis="armeabi-v7a x86 arm64-v8a x86_64"
 configure_params=""
@@ -42,6 +47,8 @@ fresh_build=true
 no_host=false
 silent=false
 custom_silent="--enable-silent-rules"
+# support build zlib use the default value linux when build on macOS.
+chost="linux"
 
 for ARGUMENT in "$@"
 do
@@ -78,6 +85,7 @@ echo "fresh_build        = $fresh_build"
 echo "no_host            = $no_host"
 echo "silent             = $silent"
 echo "custom_silent      = $custom_silent"
+echo "chost              = $chost"
 echo ""
 
 # check to create installation dir of built library files
@@ -145,6 +153,7 @@ do
   export LD=$TOOLCHAIN/bin/ld
   export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
   export STRIP=$TOOLCHAIN/bin/llvm-strip
+  export CHOST=$chost
 
   # only confiture and make clean when there's no flag telling to ignore
   if [ "$fresh_build" == "true" ]

--- a/build_aria2.sh
+++ b/build_aria2.sh
@@ -36,7 +36,12 @@ then
   exit 1
 fi
 
-host_tag=linux-x86_64
+# check system is linux or darwin
+if [ "$(uname)" == "Darwin" ]; then
+    host_tag=darwin-x86_64
+else
+    host_tag=linux-x86_64
+fi
 minsdkversion=18
 target_abis="armeabi-v7a x86 arm64-v8a x86_64"
 silent=false

--- a/build_libssh2.sh
+++ b/build_libssh2.sh
@@ -5,6 +5,7 @@ echo -e "\n\n----- Build libssh2 (`git describe --tags`) -----"
 ./buildconf
 
 INSTALL_DIR="$1"
+export LDFLAGS="$LDFLAGS -latomic"
 
 echo -e "\n++ Build libssh2 armeabi-v7a ++"
 ../androidbuildlib out_path=../libs \

--- a/build_openssl.sh
+++ b/build_openssl.sh
@@ -2,8 +2,15 @@
 
 cd openssl
 INSTALL_DIR="$1"
-ANDROID_NDK_ROOT="$NDK"
-PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
+# openssl configure script will check ANDROID_NDK_ROOT
+export ANDROID_NDK_ROOT="$NDK"
+# check system is linux or darwin
+if [ "$(uname)" == "Darwin" ]; then
+    host_tag=darwin-x86_64
+else
+    host_tag=linux-x86_64
+fi
+export PATH=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$host_tag/bin:$PATH
 echo -e "\n\n----- Build openssl (`git describe --tags`) -----"
 
 VERBOSE_FLAGS=""
@@ -12,26 +19,30 @@ if [ "$SILENT" == "true" ]; then
 	echo "Using non-verbose mode"
 fi
 
+# Nov 10, 2021, openssl fix it. https://github.com/openssl/openssl/pull/15086
+# now we can use -latomic to fix the build error.
+LDFLAGS="-latomic"
+
 echo -e "\n++ Build openssl armeabi-v7a ++"
-./Configure no-shared android-arm -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/armeabi-v7a"
+./Configure no-shared android-arm -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/armeabi-v7a" $LDFLAGS
 make $VERBOSE_FLAGS clean
 make -j4 $VERBOSE_FLAGS
 make install_sw
 
 echo -e "\n++ Build openssl arm64-v8a ++"
-./Configure no-shared android-arm64 -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/arm64-v8a"
+./Configure no-shared android-arm64 -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/arm64-v8a" $LDFLAGS
 make $VERBOSE_FLAGS clean
 make -j4 $VERBOSE_FLAGS
 make install_sw
 
 echo -e "\n++ Build openssl x86 ++"
-./Configure no-shared android-x86 -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/x86"
+./Configure no-shared android-x86 -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/x86" $LDFLAGS
 make $VERBOSE_FLAGS clean
 make -j4 $VERBOSE_FLAGS
 make install_sw
 
 echo -e "\n++ Build openssl x86_64 ++"
-./Configure no-shared android-x86_64 -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/x86_64"
+./Configure no-shared android-x86_64 -D__ANDROID_API__=21 --prefix="$INSTALL_DIR/x86_64" $LDFLAGS
 make $VERBOSE_FLAGS clean
 make -j4 $VERBOSE_FLAGS
 make install_sw


### PR DESCRIPTION
I do more tests and configuration on macOS as an Android developer.
The build scripts use host_tag as linux-x86_64, which will prevent compiling c/c++ because we can't find NDK prebuilt tools.
I add some updates to support its build on macOS.